### PR TITLE
Add 2026 event configuration and menu to hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -61,7 +61,7 @@ enableMissingTranslationPlaceholders = true
   city = "Sherbrooke, Québec, Canada"
   timeanddate_cityid = 165
   themeColor = "#d71d1f"
-  [params.2025.logos]
+  [params.2026.logos]
     jumbo = "/images/2026/background-2026.png"
     header = "/images/2026/tqc-logo-2026.png"
     banner = "/images/2026/banner-2026.jpg"

--- a/hugo.toml
+++ b/hugo.toml
@@ -57,6 +57,15 @@ enableMissingTranslationPlaceholders = true
     header = "/images/2025/tqc-logo-2025.png"
     banner = "/images/2025/banner-2025.jpg"
 
+[params.2026]
+  city = "Sherbrooke, Québec, Canada"
+  timeanddate_cityid = 165
+  themeColor = "#d71d1f"
+  [params.2025.logos]
+    jumbo = "/images/2026/background-2026.png"
+    header = "/images/2026/tqc-logo-2026.png"
+    banner = "/images/2026/banner-2026.jpg"
+
 [params.logos]
     footer = "/images/logos/netlify-color-accent.svg"
     footer_link = "https://www.netlify.com"
@@ -115,6 +124,30 @@ enableMissingTranslationPlaceholders = true
     weight = 50
     identifier = "committees"
     pageRef = "/2025/team"
+
+  [[menu.2026]]
+    name = "Home"
+    weight = 10
+    identifier = "home"
+    pageRef = '/2026'
+  [[menu.2026]]
+    name = "Technical Program"
+    weight = 20
+    identifier = "technical-program"
+  [[menu.2026]]
+    name = "Attend"
+    weight = 30
+    identifier = "attend"
+  [[menu.2026]]
+    name = "Sponsors"
+    weight = 40
+    identifier = "sponsors"
+    pageRef = "/2026/partners"
+  [[menu.2026]]
+    name = "Committees"
+    weight = 50
+    identifier = "committees"
+    pageRef = "/2026/team"
 
 
 


### PR DESCRIPTION
This pull request updates the configuration in `hugo.toml` to add support for the upcoming 2026 event, including new branding assets and a dedicated navigation menu. The most important changes are grouped below:

2026 event configuration:

* Added a new `[params.2026]` section with details for the 2026 event, including `city`, `timeanddate_cityid`, and `themeColor`. Also added new logo paths under `[params.2025.logos]` for 2026 branding assets (`jumbo`, `header`, `banner`).

Navigation updates for 2026:

* Introduced a new `menu.2026` section, defining navigation items for the 2026 event: Home, Technical Program, Attend, Sponsors, and Committees, each with appropriate weights and page references.

---
Linked Issue: https://github.com/SherbrookeYTQC/tqc-website/issues/4